### PR TITLE
Issue #6: Add null check for not found icons

### DIFF
--- a/fab.android.js
+++ b/fab.android.js
@@ -34,7 +34,8 @@
 
           if(ImageSource.isFileOrResourcePath(this.icon)){
             iconDrawable = ImageSource.fromFileOrResource(this.icon);
-            this._android.setImageBitmap(iconDrawable.android);
+            if(iconDrawable != null)
+              this._android.setImageBitmap(iconDrawable.android);
           }
           else{
             var drawableId = android.content.res.Resources.getSystem().getIdentifier(this.icon, "drawable", "android");


### PR DESCRIPTION
Just add a null check to bypass icon set when the icon is not found. This is going to render an empty FAB.