### PR TITLE
Fix for iOS getting resized with NaN numbers

### DIFF
--- a/fab.ios.js
+++ b/fab.ios.js
@@ -68,6 +68,7 @@ var FloatingActionButtonStyler = (function () {
     // WIDTH\HEIGHT
     FloatingActionButtonStyler.setSizeProperty = function (view, newValue) {
         var fab = view.ios;
+        if (isNaN(newValue)) return;
         fab.bounds.size.width = newValue;
         fab.bounds.size.height = newValue;
 


### PR DESCRIPTION
During some re-sizes/recalcs; iOS sends NaN through -- this eliminates those values from being considered.  (If you let NaN through, the component crashes!)